### PR TITLE
fixed extension point name

### DIFF
--- a/src/main/resources/plugin.xml
+++ b/src/main/resources/plugin.xml
@@ -5,7 +5,7 @@
 		<import plugin="org.liveontologies.protege.explanation.justification.service"/>
 	</requires>
 
-	<extension id="JustificationService" point="org.liveontologies.protege.explanation.justification.JustificationService">
+	<extension id="JustificationService" point="org.liveontologies.protege.explanation.justification.JustificationComputationService">
 		<name value="Justification Service" />
 		<class value="org.liveontologies.protege.justification.blackbox.BlackBoxJustificationComputationService" />
 	</extension>


### PR DESCRIPTION
The extension point "JustificationService" in `protege-justification-explanation` was renamed to "JustificationComputationService". I changed the `plugin.xml` accordingly. Fixes #3.